### PR TITLE
Update events

### DIFF
--- a/events/2022/2022-11-09.md
+++ b/events/2022/2022-11-09.md
@@ -1,5 +1,5 @@
 ---
-title: \#01 The Beginning
+title: "#01 The Beginning"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2023/2023-02-28.md
+++ b/events/2023/2023-02-28.md
@@ -1,5 +1,5 @@
 ---
-title: \#02 Building Up
+title: "#02 Building Up"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2023/2023-05-30.md
+++ b/events/2023/2023-05-30.md
@@ -1,5 +1,5 @@
 ---
-title: \#03 Is a charm
+title: "#03 Is a charm"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2023/2023-09-19.md
+++ b/events/2023/2023-09-19.md
@@ -1,5 +1,5 @@
 ---
-title: \#04 The Room
+title: "#04 The Room"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2023/2023-11-15.md
+++ b/events/2023/2023-11-15.md
@@ -1,5 +1,5 @@
 ---
-title: \#05 The Cake
+title: "#05 The Cake"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2024/2024-03-05.md
+++ b/events/2024/2024-03-05.md
@@ -1,5 +1,5 @@
 ---
-title: \#06 The Eggs
+title: "#06 The Eggs"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2024/2024-05-28.md
+++ b/events/2024/2024-05-28.md
@@ -1,5 +1,5 @@
 ---
-title: \#07 The Son
+title: "#07 The Son"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---

--- a/events/2025/2025-01-15.md
+++ b/events/2025/2025-01-15.md
@@ -1,5 +1,5 @@
 ---
-title: \#08 The Passenger
+title: "#08 The Passenger"
 layout: col-sidebar
 tags: lisboa, owasp-lisboa, chapter-portugal, portugal
 ---
@@ -48,7 +48,7 @@ Prefers live demos and cyberattacks simulations."
 #### Nick Vinson
 "Nick has 14 years in the tech industry spanning across both security and engineering roles. In his current role Nick leads the Product Security function at Snyk, a cybersecurity company that builds developer-first security products."
 
-[LinkedIn](https://www.linkedin.com/in/nick-vinson-a147971bb//)
+[LinkedIn](https://www.linkedin.com/in/nick-vinson-a147971bb/)
 
 ### Pictures from the meetup
 

--- a/tab_pastevents.md
+++ b/tab_pastevents.md
@@ -12,7 +12,7 @@ tags: lisboa
 
 # 2025
 
-{% assign page_event_2025 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2025'" %}
+{% assign page_event_2025 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2025'" | reverse %}
 
 {% for page in page_event_2025 %}
 * [{{ page.title }}]({{site.baseurl }}{{ page.url }})
@@ -20,7 +20,7 @@ tags: lisboa
 
 # 2024
 
-{% assign page_event_2024 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2024'" %}
+{% assign page_event_2024 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2024'" | reverse %}
 
 {% for page in page_event_2024 %}
 * [{{ page.title }}]({{site.baseurl }}{{ page.url }})
@@ -28,7 +28,7 @@ tags: lisboa
 
 # 2023
 
-{% assign page_event_2023 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2023'" %}
+{% assign page_event_2023 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2023'" | reverse %}
 
 {% for page in page_event_2023 %}
 * [{{ page.title }}]({{site.baseurl }}{{ page.url }})
@@ -36,7 +36,7 @@ tags: lisboa
 
 # 2022
 
-{% assign page_event_2022 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2022'" %}
+{% assign page_event_2022 = site.pages | sort: 'name' | where_exp: "page", "page.path contains 'events/2022'" | reverse %}
 
 {% for page in page_event_2022 %}
 * [{{ page.title }}]({{site.baseurl }}{{ page.url }})


### PR DESCRIPTION
- Escaping the `#` in the titles correctly.
- Displaying the events in reverse chronological order in the Past Events tab.

Previewed locally on Jekyll.